### PR TITLE
Avoid exception in section.display if no new-section defined

### DIFF
--- a/slides.typ
+++ b/slides.typ
@@ -2,7 +2,7 @@
 // ======== GLOBAL STATE ========
 // ==============================
 
-#let section = state("section", none)
+#let section = state("section", "")
 #let subslide = counter("subslide")
 #let logical-slide = counter("logical-slide")
 #let repetitions = counter("repetitions")

--- a/slides.typ
+++ b/slides.typ
@@ -268,7 +268,7 @@
                 stroke: strokes.at(position),
                 width: 100%,
                 inset: .3em,
-                text(.5em, body)
+                text(.5em, [body])
             )
         }
 


### PR DESCRIPTION
As proposed by @astrale-sharp, this fixes #20.
The documentation explains for the `display` function:
```
A function which receives the value of the state and can return arbitrary content which is then displayed. If this is omitted, the value is directly displayed.
```
I guess directly display the `none` value is somehow an issue for the compiler (I'm not sure what it's supposed to be display by typst for `none`) but one strange thing is that the following passes:
```
#let test = state("test", none)
test.display()
```