### PR TITLE
bristol optional logos and watermark

### DIFF
--- a/book/src/theme-gallery/index.md
+++ b/book/src/theme-gallery/index.md
@@ -135,7 +135,7 @@ It features a University of Bristol branding by default, however the logos and c
 - `watermark`: file path for a watermark image to span the title slide, default "bristol/watermark.svg"
 - `logo`: file path for a logo image to appear on every slide, default "bristol/logo.svg"
 - `secondlogo`: file path for an additional logo image, to appear on the first slide only, default "bristol/secondlogo.svg"
-Default logos are shipped with the theme, however they can be swapped out for another institution's branding by changing the `watermark`, `logo`, and `secondlogo` file paths when instantiating the theme.
+Default logos are shipped with the theme, however they can be swapped out for another institution's branding by changing the `watermark`, `logo`, and `secondlogo` file paths or disabled by setting them to `none` when instantiating the theme.
 
 ### Variants
 - `title slide`: shows a nicely formatted title slide
@@ -158,7 +158,7 @@ Default logos are shipped with the theme, however they can be swapped out for an
     theme: bristol-theme(),
 )
 
-#slide(theme-variant: "title")
+#slide(theme-variant: "title slide")
 
 #new-section("section name")
 

--- a/themes/bristol.typ
+++ b/themes/bristol.typ
@@ -13,13 +13,19 @@
 
     let title-slide(slide-info, bodies) = {
 
-     	place(image(watermark, width:100%))
+        if watermark != none {
+     	    place(image(watermark, width:100%))
+        }
 
         v(5%)
 	grid(columns: (5%, 1fr, 1fr, 5%),
 	    [],
-	    align(bottom + left)[#image(logo, width:40%)],
-	    align(bottom + right)[#image(secondlogo, width:40%)],
+            if logo != none {
+	            align(bottom + left)[#image(logo, width:40%)]
+            },
+            if secondlogo != none {
+	            align(bottom + right)[#image(secondlogo, width:40%)]
+            },
 	    [])
 
         v(-10%)
@@ -96,7 +102,9 @@
 
         // header
         decoration("header", grid(columns: (1fr, 1fr),
-	            align(left, image(logo, width:35%)),
+            if logo != none {
+                align(left, image(logo, width:35%))
+            },
 		    align(right, grid(rows: (.5em, .5em),
 		        text(color, .7em)[#data.short-title],
 			[],


### PR DESCRIPTION
I noticed that the `bristol.typ` mixes tabs and spaces a lot, might make sense to clean that up.
