### PR TITLE
Fix theme variant error in Theme Gallery

### DIFF
--- a/book/src/theme-gallery/index.md
+++ b/book/src/theme-gallery/index.md
@@ -158,7 +158,7 @@ Default logos are shipped with the theme, however they can be swapped out for an
     theme: bristol-theme(),
 )
 
-#slide(theme-variant: "title")
+#slide(theme-variant: "title slide")
 
 #new-section("section name")
 


### PR DESCRIPTION
There is an error in the Theme Gallery section of the book.
The theme variant is called **title slide** instead of **title**.