### PR TITLE
Fix University: focus-slide

### DIFF
--- a/themes/university.typ
+++ b/themes/university.typ
@@ -190,7 +190,7 @@
 }
 
 #let focus-slide(background-color: none, background-img: none, body) = {
-  let background-color = if background-img == none and background-colour ==  none {
+  let background-color = if background-img == none and background-color ==  none {
     rgb("#0C6291")
   } else {
     background-color


### PR DESCRIPTION
For the University theme there was a typo in the `focus-slide` function where at some point the variable `background-colour` was used instead of `background-color`. This PR fixes the function.