### PR TITLE
Impove PDF bookmarks

### DIFF
--- a/themes/clean.typ
+++ b/themes/clean.typ
@@ -104,7 +104,7 @@
   logic.polylux-slide(content)
 }
 
-#let slide(title: none, columns: none, gutter: none, ..bodies) = {
+#let slide(title: none, columns: none, gutter: none, bookmarked: false, ..bodies) = {
   let header = align(top, locate( loc => {
     let color = clean-color.at(loc)
     let logo = clean-logo.at(loc)
@@ -162,10 +162,9 @@
 
   let body = pad(x: .0em, y: .5em, grid(columns: columns, gutter: gutter, ..bodies))
   
-
   let content = {
     if title != none {
-      heading(level: 2, title)
+      heading(level: 2, bookmarked: bookmarked, title)
     }
     body
   }
@@ -188,7 +187,7 @@
     set align(center + horizon)
     show: block.with(stroke: ( bottom: 1mm + color ), inset: 1em,)
     set text(size: 1.5em)
-    strong(name)
+    heading(level: 2, name)
     helpers.register-section(name)
   })
   logic.polylux-slide(content)

--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -85,14 +85,14 @@
   logic.polylux-slide(content)
 }
 
-#let slide(title: none, body) = {
+#let slide(title: none, bookmarked: false, body) = {
   let header = {
     set align(top)
     if title != none {
       show: m-cell.with(fill: m-dark-teal, inset: 1em)
       set align(horizon)
       set text(fill: m-extra-light-gray, size: 1.2em)
-      strong(title)
+      heading(level: 2, bookmarked: bookmarked, title)
     } else { [] }
   }
 
@@ -128,7 +128,7 @@
     set align(horizon)
     show: pad.with(20%)
     set text(size: 1.5em)
-    name
+    heading(level: 2, name)
     block(height: 2pt, width: 100%, spacing: 0pt, m-progress-bar)
   }
   logic.polylux-slide(content)

--- a/themes/university.typ
+++ b/themes/university.typ
@@ -102,6 +102,7 @@
   header: none,
   footer: none,
   new-section: none,
+  bookmarked: false,
   ..bodies
 ) = {
   let bodies = bodies.pos()
@@ -128,6 +129,7 @@
     } else { [] }
   })
 
+  let should-bookmark = bookmarked or new-section != none
   let header-text = {
     if header != none {
       header
@@ -139,7 +141,7 @@
         let colors = uni-colors.at(loc)
         block(fill: colors.c, inset: (x: .5em), grid(
           columns: (60%, 40%),
-          align(top + left, heading(level: 2, text(fill: colors.a, title))),
+          align(top + left, heading(level: 2, bookmarked: should-bookmark, text(fill: colors.a, title))),
           align(top + right, text(fill: colors.a.lighten(65%), helpers.current-section))
         ))
       })


### PR DESCRIPTION
Fixes #32.

Like mentioned in #32, polylux currently creates too many PDF bookmarks and users have little control over this. This PR addresses the issue.

The themes `clean` and `university` no longer create a bookmark for every slide title. Only when a title is given and the `bookmarked` parameter is `true` do we add a bookmark.

For `clean` and `metropolis`, when a `new-section-slide` is created, it is bookmarked.

For `university`, when the `new-section` parameter is set, we bookmark this new section heading.

Someone please check if I broke some themes.