### PR TITLE
Feature: `fit-to-width`

### DIFF
--- a/polylux.typ
+++ b/polylux.typ
@@ -2,4 +2,4 @@
 #import "logic.typ"
 #import "logic.typ": polylux-slide, uncover, only, alternatives, alternatives-match, alternatives-fn, alternatives-cases, one-by-one, line-by-line, list-one-by-one, enum-one-by-one, terms-one-by-one, pause, enable-handout-mode
 #import "utils/utils.typ"
-#import "utils/utils.typ": polylux-outline, fit-to-height, side-by-side, pdfpc
+#import "utils/utils.typ": polylux-outline, fit-to-height, fit-to-width, side-by-side, pdfpc

--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -40,7 +40,7 @@
 #let last-slide-number = locate(loc => logic.logical-slide.final(loc).first())
 
 
-// HEIGHT FITTING
+// HEIGHT/WIDTH FITTING
 
 #let _size-to-pt(size, styles, container-dimension) = {
   let to-convert = size
@@ -126,6 +126,25 @@
         )
       })
     })
+  })
+}
+
+#let fit-to-width(width: 100%, content) = {
+  style(styles => {
+    let content-size = measure(content, styles)
+    let content-width = content-size.width
+    if width < content-width {
+      let ratio = width / content-width * 100%
+      // The first box keeps content from prematurely wrapping
+      let scaled = scale(
+        box(content, width: content-width), origin: top + left, x: ratio, y: ratio
+      )
+      // The second box lets typst know the post-scaled dimensions, since `scale`
+      // doesn't update layout information
+      box(scaled, width: width, height: content-size.height * ratio)
+    } else {
+      content
+    }
   })
 }
 


### PR DESCRIPTION
Use case: I want my slide header to always take up one line, regardless of text size. This function solves the problem by allowing text to shrink to it's requested width

```typst
show heading.where(level: 2): it => {
  layout(layout-size => {
    fit-to-width(width: layout-size.width * 75%, it)
  })
}

#set page(height: auto)
#slide[
  == Lorem
]

#slide[
  == #lorem(10)
]

#slide[
  == #lorem(15)
]
```

Results in:

![image](https://github.com/andreasKroepelin/polylux/assets/23620506/2ef0da6a-6ff5-40fc-9662-45ed53b9f076)