### PR TITLE
Fix pagebreak for first slide

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -266,7 +266,7 @@
 
 #let polylux-slide(body) = {
   locate( loc => {
-    if counter(page).at(loc).first() > 1 {
+    if logical-slide.at(loc).first() > 0 {
       pagebreak(weak: true)
     }
   })

--- a/tests/first-slide.typ
+++ b/tests/first-slide.typ
@@ -1,0 +1,17 @@
+#import "../polylux.typ": *
+
+#set page(paper: "presentation-16-9", height: auto)
+#set text(size: 25pt)
+
+#let slide = polylux-slide
+
+#slide[
+  == First slide
+
+  This is supposed to appear on the first PDF page.
+]
+
+#slide[
+  == Second slide
+  #lorem(10)
+]


### PR DESCRIPTION
Fixes #97
I think we still need this somewhat "complicated" logic because `pagebreak(weak: true)` is not as weak as we would need, kinda. If we do not check if we are after the first logical slide, we get a white first page for the demo example, for instance.
@ntjess 