### PR TITLE
Fix typo in `last-minutes` variable in utils/pdfpc

### DIFF
--- a/utils/pdfpc.typ
+++ b/utils/pdfpc.typ
@@ -55,7 +55,7 @@
   }
 
   if last-minutes != none {
-    [ #metadata((t: "LastMinutes", v: last_minutes)) <pdfpc> ]
+    [ #metadata((t: "LastMinutes", v: last-minutes)) <pdfpc> ]
   }
 
   if note-font-size != none {


### PR DESCRIPTION
That error quite surprised me when I tried to use `pdfpc config` for my Rust course presentation at Thursday. I guess it could help somebody else.

Many thanks for Polylux anyway, it is very cool, as is support for external tooling. Though finding precompiled binary for `pdfpc` for Windows was pretty hard. Hopefully, that will improve soon, if that Windows fork will be merged in `pdfpc`.