### PR TITLE
Add mdbook-typst-highlight

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -36,6 +36,11 @@ jobs:
         run: |
           mkdir bin
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+      - name: Install mdbook-typst-highlight
+        run: |
+          mkdir typst-highlight
+          curl -sSL https://github.com/sitandr/mdbook-typst-highlight/releases/download/v0.1.0/mdbook-typst-highlight-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=typst-highlight
+          echo `pwd`/typst-highlight >> $GITHUB_PATH
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/book/book.toml
+++ b/book/book.toml
@@ -11,3 +11,6 @@ site-url = "/polylux/book/"
 [output.html.code.hidelines]
 typ = "~"
 
+[preprocessor.typst-highlight]
+#disable_inline = true
+#highlight_without_lang = true


### PR DESCRIPTION
See running version with highlight there: https://sitandr.github.io/polylux/book/dynamic/syntax.html

I'm not sure, maybe it will be better to disable highlighting inline code, especially considering that `#var` and `#fn()` are colored differently. I guess it should be up to you, so I've left two lines commented in `book.toml` (the second one is for the case you are lazy putting ` ```typ ` at code blocks everywhere.