### PR TITLE
fix: `alternatives` utils should not modify the layout

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -137,15 +137,8 @@
   let subslides = subslides-contents.map(it => it.first())
   let contents = subslides-contents.map(it => it.last())
   style(styles => {
-    let sizes = contents.map(c => measure(c, styles))
-    let max-width = calc.max(..sizes.map(sz => sz.width))
-    let max-height = calc.max(..sizes.map(sz => sz.height))
     for (subslides, content) in subslides-contents {
-      only(subslides, box(
-        width: max-width,
-        height: max-height,
-        align(position, content)
-      ))
+      only(subslides, content)
     }
   })
 }


### PR DESCRIPTION
Hi,

I'm working with a custom theme for work and have encountered an issue when using the `alternatives` helper on a focus slide. Specifically, using `alternatives` ends up breaking the layout, making it difficult to incorporate into my work.

#### The Issue

When I use `alternatives`, the `content` gets wrapped in a `box` element with specific `width` and `height` attributes. I find this to be problematic for a utility helper, as it alters the layout in an unexpected way.

#### Proposed Solution

I've opened a PR that proposes a fix for this issue. The PR removes the `box` wrapping around the `content`, thus eliminating the layout modification. I believe utility helpers like `alternatives` and alike should strictly implement specific logic without affecting layout.

I've been using this fix in my own work and haven't encountered any issues so far.

I'd love to hear your thoughts on this. Do you share the same vision that utility helpers like `alternatives` should not modify the layout?

Your feedback would be highly appreciated.