### PR TITLE
Package pdfpc-extractor for NixOS users

### DIFF
--- a/book/src/external/pdfpc.md
+++ b/book/src/external/pdfpc.md
@@ -105,14 +105,27 @@ assemble the correct `.pdfpc` file yourself.
 However, this tedious task is better solved by the `polylux2pdfpc` tool.
 
 ### Installation
+#### From Source
 If you have [Rust](https://www.rust-lang.org/tools/install) installed, you can
 simply run
 ```sh
 cargo install --git https://github.com/andreasKroepelin/polylux/ --branch release
 ```
+
+#### Arch Linux
 If you use Arch Linux btw, you can also install `polylux2pdfpc` from the AUR
 package [polylux2pdfpc-git](https://aur.archlinux.org/packages/polylux2pdfpc-git)
 (thank you to Julius Freudenberger!)
+
+
+#### NixOS
+1. Add the flake to your own `flake.nix` as input:
+`polylux.url = "github:andreasKroepelin/polylux";`
+2. Use the package `inputs.polylux.defaultPackage.${pkgs.system}`, which will build `pdfpc-extractor`
+
+For development purposes, run
+- `nix build` to build the package into the `result` directory
+- `nix develop` to enter a development shell to run `cargo` commands
 
 ### Usage
 You invoke `polylux2pdfpc` with the same arguments you would also give to `typst

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1698153314,
+        "narHash": "sha256-TunvZMCxXHvU6fz5kq3XTLfojIvTDlbFGfPUFtwCU5o=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "06a99941d72e2202ed62b8aa08b9869817fea56f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697915759,
+        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1697723726,
+        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "A package for creating slides in Typst";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    naersk,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = (import nixpkgs) {
+          inherit system;
+        };
+
+        naersk' = pkgs.callPackage naersk {};
+      in rec {
+        # For `nix build` & `nix run`:
+        defaultPackage = naersk'.buildPackage {
+          src = ./pdfpc-extractor;
+          buildInputs = with pkgs; [];
+        };
+
+        # For `nix develop` (optional, can be skipped):
+        devShell = pkgs.mkShell rec {
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+          ];
+          LD_LIBRARY_PATH = nixpkgs.lib.makeLibraryPath buildInputs;
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR will add a NixOS flake, which builds the `pdfpc-extractor` and exposes it as a package.

# Usage
1. Add the flake to your own `flake.nix` as input
2. Use the package `inputs.polylux.defaultPackage.${pkgs.system}` (under the assumption that the flake was named `polylux` in your inputs), which will build pdfpc-extractor

# Dev env
Either run 
- `nix build` to build the package into the result directory
or run
- `nix develop` to enter a dev env where you should be able to run `cargo build` commands as usual