### PR TITLE
Block mode for `#alternatives` family

### DIFF
--- a/book/src/dynamic/alternatives.md
+++ b/book/src/dynamic/alternatives.md
@@ -66,6 +66,16 @@ All functions described on this page have such a `position` argument.
 Similar to `#one-by-one`, `#alternatives` also has an optional `start` argument
 that works just the same.
 
+### Block mode
+
+By default, `#alternatives` lays out elements as if they are inline (it wraps
+them in a `#box`). Sometimes, this will not be desirable, such as when laying
+out images using `#alternatives`.
+
+If the `block_mode` argument is set to `true`, then `#alternatives` will lay
+out elements as block level elements, taking up the full available width and
+adjusting to use the height of the largest element.
+
 ## `#alternatives-match`
 `#alternatives` has a couple of "cousins" that might be more convenient in some
 situations.

--- a/logic.typ
+++ b/logic.typ
@@ -127,7 +127,11 @@
   }
 }
 
-#let alternatives-match(subslides-contents, position: bottom + left) = {
+#let alternatives-match(
+  subslides-contents,
+  position: bottom + left,
+  block_mode: false
+) = context {
   let subslides-contents = if type(subslides-contents) == "dictionary" {
     subslides-contents.pairs()
   } else {
@@ -136,8 +140,22 @@
 
   let subslides = subslides-contents.map(it => it.first())
   let contents = subslides-contents.map(it => it.last())
-  style(styles => {
-    let sizes = contents.map(c => measure(c, styles))
+  
+  if block_mode {
+    layout(size => {
+      // Determine how much height each contents will take when given full width
+      let sizes = contents.map(c => measure(block(width: size.width, c)))
+      let max-height = calc.max(..sizes.map(sz => sz.height))
+      for (subslides, content) in subslides-contents {
+        only(subslides, block(
+          width: size.width,
+          height: max-height,
+          align(position, content)
+        ))
+      }
+    })
+  } else {
+    let sizes = contents.map(c => measure(c))
     let max-width = calc.max(..sizes.map(sz => sz.width))
     let max-height = calc.max(..sizes.map(sz => sz.height))
     for (subslides, content) in subslides-contents {
@@ -147,7 +165,8 @@
         align(position, content)
       ))
     }
-  })
+  }
+
 }
 
 #let alternatives(

--- a/tests/alternatives.typ
+++ b/tests/alternatives.typ
@@ -39,3 +39,23 @@
 
   #alternatives-fn(count: 5, subslide => numbering("(i)", subslide))
 ]
+
+#polylux-slide[
+  == Test that block mode works
+
+  #alternatives(block_mode: true)[
+    This is inline content
+  ][
+    #rect(width: 100%, height: 60pt, fill: red)[
+      This rectangle should fill the page and have a red background
+    ]
+  ]
+
+  #alternatives(position: horizon + center, block_mode: true)[
+    #rect(width: 100%, height: 60pt, fill: green)[
+      This rectangle should fill the page and have a green background and
+      be `horizon + center` centered.
+    ]
+  ]
+
+]


### PR DESCRIPTION
First, thanks for this great library!

Currently, `#alternatives` always lays out elements as inline elements (wrapping them in a `box`).

This change adds a mode where `alternatives` can lay elements out as block elements. There are two reasons I can think of that someone might want to do this.

- For relative width elements, it makes sense to have them laid out as a block and take up the full width of the page, rather than being given 0 width and then not getting laid out properly. See issue #127, which this fixes.
- For content which one would like to align on the page, we can't do this the naive way by passing it to `#alternatives` directly since it gets put in a minimum width container that is then inlined. To work around this, one would have to put an align statement outside the `alternatives` or put the content inside a `block` before passing it to `#alternatives`.

Thanks for looking at this! I also added a test and a section to the book. Let me know if anything else would help to make this easier to merge (I see that you mention you're quite time-poor in other PRs).