### PR TITLE
themes/university: Fix section handling when no title is given

### DIFF
--- a/themes/university.typ
+++ b/themes/university.typ
@@ -121,12 +121,13 @@
   })
 
   let header-text = {
+    if new-section != none {
+      utils.register-section(new-section)
+    }
+
     if header != none {
       header
-    } else if title != none {
-      if new-section != none {
-        utils.register-section(new-section)
-      }
+    } else if title != none or utils.current-section != none {
       locate( loc => {
         let colors = uni-colors.at(loc)
         block(fill: colors.c, inset: (x: .5em), grid(


### PR DESCRIPTION
Now always register new section if new-section argument is set, and display the header additionally if there is a current section but no title.

Closes #169.