### PR TITLE
Add align argument for side by side

### DIFF
--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -131,12 +131,12 @@
 
 // SIDE BY SIDE
 
-#let side-by-side(columns: none, gutter: 1em, ..bodies) = {
+#let side-by-side(columns: none, gutter: 1em, align: auto, ..bodies) = {
   let bodies = bodies.pos()
   let columns = if columns ==  none { (1fr,) * bodies.len() } else { columns }
   if columns.len() != bodies.len() {
     panic("number of columns must match number of content arguments")
   }
 
-  grid(columns: columns, gutter: gutter, ..bodies)
+  grid(columns: columns, gutter: gutter, align: align, ..bodies)
 }


### PR DESCRIPTION
This adds the possibility to pass the `align` argument through `side-by-side` and into grid. This is especially useful for equations, where math-mode has a greater line height than text (and would otherwise not be vertically-centered).