### PR TITLE
Make transparent uncover actually transparent

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -10,7 +10,7 @@
   if mode == "invisible" {
     hide(body)
   } else if mode == "transparent" {
-    text(gray.lighten(50%), body)
+    text(text.fill.transparentize(50%), body)
   } else {
     panic("Illegal cover mode: " + mode)
   }


### PR DESCRIPTION
Currently, `uncover` only replaces the text fill color with `gray.lighten(50%)`. This ignores previous text colors as well as background colors that would normally show through. This new version uses the newly added `transparentize` to set the text fill color to `text.fill.transparentize(50%)`. Since the mode is already called `transparent`, this is more intuitive.