### PR TITLE
Context replaces locate

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -98,19 +98,19 @@
 }
 
 #let _conditional-display(visible-subslides, reserve-space, mode, body) = {
-  locate( loc => {
-    let vs = if reserve-space and handout-mode.at(loc) {
+  context{
+    let vs = if reserve-space and handout-mode.at(here()) {
       (:)
     } else {
       visible-subslides
     }
     repetitions.update(rep => calc.max(rep, _last-required-subslide(vs)))
-    if _check-visible(subslide.at(loc).first(), vs) {
+    if _check-visible(subslide.at(here()).first(), vs) {
       body
     } else if reserve-space {
       _slides-cover(mode, body)
     }
-  })
+  }
 }
 
 #let uncover(visible-subslides, mode: "invisible", body) = {
@@ -127,7 +127,7 @@
   }
 }
 
-#let alternatives-match(subslides-contents, position: bottom + left) = {
+#let alternatives-match(subslides-contents, position: bottom + left, width: none, stroke: none, outset: none) = {
   let subslides-contents = if type(subslides-contents) == "dictionary" {
     subslides-contents.pairs()
   } else {
@@ -136,8 +136,8 @@
 
   let subslides = subslides-contents.map(it => it.first())
   let contents = subslides-contents.map(it => it.last())
-  style(styles => {
-    let sizes = contents.map(c => measure(c, styles))
+  context{
+    let sizes = contents.map(c => measure(c))
     let max-width = calc.max(..sizes.map(sz => sz.width))
     let max-height = calc.max(..sizes.map(sz => sz.height))
     for (subslides, content) in subslides-contents {
@@ -147,7 +147,7 @@
         align(position, content)
       ))
     }
-  })
+  }
 }
 
 #let alternatives(
@@ -262,16 +262,16 @@
   }
 }
 
-#let paused-content(body) = locate( loc => {
-  let current-subslide = subslide.at(loc).first()
-  let current-pause-counter = pause-counter.at(loc).first()
+#let paused-content(body) = context{
+  let current-subslide = subslide.at(here()).first()
+  let current-pause-counter = pause-counter.at(here()).first()
 
   if current-subslide > current-pause-counter {
     body
   } else {
     hide(body)
   }
-})
+}
 
 #let polylux-slide(body) = {
   context {

--- a/logic.typ
+++ b/logic.typ
@@ -247,7 +247,7 @@
 }
 
 #let pause = {
-  // We need two separate `locate`s because `repetitions` needs to be updated
+  // We need two separate `context`s because `repetitions` needs to be updated
   // using the new value of `pause-counter`.
   context {
     if not handout-mode.get() {
@@ -255,7 +255,10 @@
     }
   }
   context {
-    repetitions.update(rep => calc.max(rep, pause-counter.get().first() + 1))
+    let tmp-counter = pause-counter.get().first()
+    repetitions.update(
+      rep => calc.max(rep, tmp-counter + 1)
+    )
   }
 }
 

--- a/themes/clean.typ
+++ b/themes/clean.typ
@@ -44,9 +44,9 @@
   watermark: none,
   secondlogo: none,
 ) = {
-  let content = locate( loc => {
-    let color = clean-color.at(loc)
-    let logo = clean-logo.at(loc)
+  let content = context{
+    let color = clean-color.at(here())
+    let logo = clean-logo.at(here())
     let authors = if type(authors) in ("string", "content") {
       ( authors, )
     } else {
@@ -100,15 +100,15 @@
       #v(1em)
       #date
     ]
-  })
+  }
   logic.polylux-slide(content)
 }
 
 #let slide(title: none, body) = {
-  let header = align(top, locate( loc => {
-    let color = clean-color.at(loc)
-    let logo = clean-logo.at(loc)
-    let short-title = clean-short-title.at(loc)
+  let header = align(top, context{
+    let color = clean-color.at(here())
+    let logo = clean-logo.at(here())
+    let short-title = clean-short-title.at(here())
 
     show: block.with(stroke: (bottom: 1mm + color), width: 100%, inset: (y: .3em))
     set text(size: .5em)
@@ -130,10 +130,10 @@
         align(horizon + right, utils.current-section)
       }
     )
-  }))
+  })
 
-  let footer = locate( loc => {
-    let color = clean-color.at(loc)
+  let footer = context{
+    let color = clean-color.at(here())
 
     block(
       stroke: ( top: 1mm + color ), width: 100%, inset: ( y: .3em ),
@@ -143,7 +143,7 @@
         logic.logical-slide.display()
       })
     )
-  })
+  }
 
   set page(
     margin: ( top: 4em, bottom: 2em, x: 1em ),
@@ -176,13 +176,13 @@
 
 #let new-section-slide(name) = {
   set page(margin: 2em)
-  let content = locate( loc => {
-    let color = clean-color.at(loc)
+  let content = context{
+    let color = clean-color.at(here())
     set align(center + horizon)
     show: block.with(stroke: ( bottom: 1mm + color ), inset: 1em,)
     set text(size: 1.5em)
     strong(name)
     utils.register-section(name)
-  })
+  }
   logic.polylux-slide(content)
 }

--- a/themes/simple.typ
+++ b/themes/simple.typ
@@ -46,10 +46,10 @@
 #let slide(body) = {
   let deco-format(it) = text(size: .6em, fill: gray, it)
   set page(
-    header: locate( loc => {
-      let sections = query(heading.where(level: 1, outlined: true).before(loc), loc)
+    header: context{
+      let sections = query(heading.where(level: 1, outlined: true).before(here()), here())
       if sections == () [] else { deco-format(sections.last().body) }
-    }),
+    },
     footer: deco-format({
       simple-footer.display(); h(1fr); logic.logical-slide.display()
     }),

--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -5,12 +5,13 @@
 // SECTIONS
 
 #let sections-state = state("polylux-sections", ())
-#let register-section(name) = locate( loc => {
+#let register-section(name) = context{
+  let loc = here()
   sections-state.update(sections => {
     sections.push((body: name, loc: loc))
     sections
   })
-})
+}
 
 #let current-section = context {
   let sections = sections-state.get()
@@ -78,10 +79,10 @@
     hidden#after-label
   ]
 
-  locate(loc => {
-    let before = query(selector(before-label).before(loc), loc)
+  context{
+    let before = query(selector(before-label).before(here()), here())
     let before-pos = before.last().location().position()
-    let after = query(selector(after-label).before(loc), loc)
+    let after = query(selector(after-label).before(here()), here())
     let after-pos = after.last().location().position()
 
     let available-height = after-pos.y - before-pos.y
@@ -126,7 +127,7 @@
         )
       })
     })
-  })
+  }
 }
 
 // SIDE BY SIDE


### PR DESCRIPTION
Replaced deprecated uses of `locate` and `style` with `context`.
Also fixed issue #188 stemming from an incorrect use of `context`.