### PR TITLE
Use logical page numbers: constant page number on overlays

### DIFF
--- a/src/logic.typ
+++ b/src/logic.typ
@@ -271,7 +271,7 @@
   // but I'm not comfortable with logic depending on pdfpc...
   let pdfpc-slide-markers(curr-subslide) = context [
     #metadata((t: "NewSlide")) <pdfpc>
-    #metadata((t: "Idx", v: counter(page).get().first() - 1)) <pdfpc>
+    #metadata((t: "Idx", v: here().page() - 1)) <pdfpc>
     #metadata((t: "Overlay", v: curr-subslide - 1)) <pdfpc>
     #metadata((t: "LogicalSlide", v: logical-slide.get().first())) <pdfpc>
   ]
@@ -288,6 +288,7 @@
     for curr-subslide in range(2, reps + 1) {
       later-counter.update(0)
       pagebreak(weak: true)
+      counter(page).update(n => n - 1)
 
       pdfpc-slide-markers(curr-subslide)
 


### PR DESCRIPTION
1. Use `here().page()` to get page index for pdfpc metadata. This remains correct if the user changes `counter(page)`. The current implementation has unexpected output if the user changes `counter(page)`.
2. Keep `counter(page)` constant on overlays. This is the same behavior as in LaTeX beamer but **differs from the current behavior**. See #107.

Note: The user should add something like `#set page(numbering: "1", footer: none)` at the beginning of the document to export page labels to the PDF document.